### PR TITLE
Fix markdown syntax for H2s in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Handheld color console based on Atmega328 with Arduino bootloader.
 
 ![Prototype](http://vilaca.eu/handheld-arduino-color-console/arduino_color_tetris.png)
 
-##Build instructions
+## Build instructions
 
 Detailed instructions are available at: http://vilaca.eu/handheld-arduino-color-console/
 
 
-##Ported games
+## Ported games
 
 - [Arduino Tetris](ArduinoTetris/)
 - [Arduino Breakout](ArduinoBreakout/)
 
 
-##Contributing
+## Contributing
 
 Feel free to make this project better by contributing with source code, improvements, bug reports, fixes, new games, etc.


### PR DESCRIPTION
The H2s currently go `##Title` and don't render, so I've added the space (`## Title`) to make them render appropriately.